### PR TITLE
Updated elgohr/Github-Release-Action to a supported version (v4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
               with:
                   github_token: ${{ secrets.RELEASE_TOKEN }}
             - name: "Create Release"
-              uses: elgohr/Github-Release-Action@master
+              uses: elgohr/Github-Release-Action@v4
               env:
                   GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
               with:


### PR DESCRIPTION
elgohr/Github-Release-Action@master is not supported anymore